### PR TITLE
fix browser can not show chart, add 'use strict'

### DIFF
--- a/src/resources/views/chart-template.blade.php
+++ b/src/resources/views/chart-template.blade.php
@@ -1,6 +1,7 @@
 <canvas id="{!! $element !!}" width="{!! $size['width'] !!}" height="{!! $size['height'] !!}">
 <script>
     (function() {
+		"use strict";
         let ctx = document.getElementById("{!! $element !!}");
         window.{!! $element !!} = new Chart(ctx, {
             type: '{!! $type !!}',


### PR DESCRIPTION
my verson Chrome 48.0.2564.97m can not show the chart unless add "use strict"