### PR TITLE
Putting namespace ahead of use statements.

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -4,9 +4,9 @@
  * This file is inspired by Builder from Laravel ChartJS - Brian Faust
  */
 
-use Illuminate\Support\Arr;
-
 namespace Fx3costa\LaravelChartJs;
+
+use Illuminate\Support\Arr;
 
 class Builder
 {


### PR DESCRIPTION
Hi There,

Firstly, I'd like to say thanks for this library, it has proven useful rather than writing my own ChartsJS interface.

This morning while working on my project and updating composer packages, I noticed that your library broke in my Laravel project with the following error message:

![image](https://user-images.githubusercontent.com/33913289/66594903-f967d080-eb67-11e9-86ac-c253e85318c1.png)

Upon forking and inspecting the code I realized that your namespace was put below your imports.  
This commit should resolve that and hopefully make the library stable again.

![image](https://user-images.githubusercontent.com/33913289/66595008-1bf9e980-eb68-11e9-95e0-21c65aacd24f.png)

Cheers.
