### PR TITLE
Change let to var

### DIFF
--- a/src/resources/views/chart-template.blade.php
+++ b/src/resources/views/chart-template.blade.php
@@ -3,7 +3,7 @@
     document.addEventListener("DOMContentLoaded", function(event) {
         (function() {
     		"use strict";
-            let ctx = document.getElementById("{!! $element !!}");
+            var ctx = document.getElementById("{!! $element !!}");
             window.{!! $element !!} = new Chart(ctx, {
                 type: '{!! $type !!}',
                 data: {


### PR DESCRIPTION
I am trying to save a webpage to PDF via [wkhtmltopdf ](https://github.com/wkhtmltopdf/wkhtmltopdf) and for wkhtmltopdf to be able to render the chart I found that `let` needs to be changed to `var`

This comment on an issue in their Github Repo explains that wkhtmltopdf is using a browser engine that cannot use new syntax.

https://github.com/wkhtmltopdf/wkhtmltopdf/issues/4240#issuecomment-459526357